### PR TITLE
Fixed remove POI bug

### DIFF
--- a/rideshare/src/main/java/com/revature/rideshare/domain/PointOfInterest.java
+++ b/rideshare/src/main/java/com/revature/rideshare/domain/PointOfInterest.java
@@ -49,7 +49,7 @@ public class PointOfInterest implements Serializable {
 	@Column(name = "LONGITUDE", nullable = false, scale = 6)
 	private double longitude;
 
-	@ManyToOne(fetch = FetchType.EAGER, cascade = CascadeType.REMOVE)
+	@ManyToOne(fetch = FetchType.EAGER)
 	private PointOfInterestType type;
 
 	public PointOfInterest() {


### PR DESCRIPTION
Removed cascade delete rule from PointOfInterest.java. This allows POIs
to be removed without a failure message. Database must be recreated and
re-populated before these changes can take place.